### PR TITLE
Fix tsconfig paths for local build

### DIFF
--- a/coreux-workspace/projects/pre-view-app/src/app/app.component.spec.ts
+++ b/coreux-workspace/projects/pre-view-app/src/app/app.component.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { AppComponent } from './app.component';
+import { CoreUxInputComponent, ThemeService } from 'coreux';
+
+describe('AppComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppComponent, CoreUxInputComponent],
+      providers: [ThemeService]
+    }).compileComponents();
+  });
+
+  it('should create the app', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+});

--- a/coreux-workspace/projects/pre-view-app/tsconfig.app.json
+++ b/coreux-workspace/projects/pre-view-app/tsconfig.app.json
@@ -4,7 +4,10 @@
     "outDir": "../../out-tsc/app",
     "types": [],
     "paths": {
-      "coreux": ["../../dist/coreux"]   // ✅ Tells TypeScript to use built library
+      "coreux": [
+        "../../dist/coreux",
+        "../coreux/src/public-api.ts"
+      ]
     }
   },
   "files": [

--- a/coreux-workspace/tsconfig.json
+++ b/coreux-workspace/tsconfig.json
@@ -5,7 +5,8 @@
   "compilerOptions": {
     "paths": {
       "coreux": [
-        "./dist/coreux"
+        "./dist/coreux",
+        "./projects/coreux/src/public-api.ts"
       ]
     },
     "outDir": "./dist/out-tsc",


### PR DESCRIPTION
## Summary
- map `coreux` library to source files as well as dist output
- update pre-view app tsconfig paths
- add simple app component test to satisfy `ng test`

## Testing
- `npx ng serve`
- `npx ng test pre-view-app --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6841465df17483268c8788be1d917677